### PR TITLE
Implementation support for "state_checkpoint_transaction" Transaction Response Type in Kaptos

### DIFF
--- a/lib/src/commonMain/kotlin/xyz/mcxross/kaptos/model/Transaction.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/kaptos/model/Transaction.kt
@@ -95,6 +95,23 @@ data class BlockMetadataTransactionResponse(
   val timestamp: String,
 ) : TransactionResponse()
 
+@Serializable
+@SerialName("state_checkpoint_transaction")
+data class StateCheckpointTransactionResponse(
+  override val type: TransactionResponseType,
+  val version: String,
+  val hash: String,
+  @SerialName("state_change_hash") val stateChangeHash: String,
+  @SerialName("event_root_hash") val eventRootHash: String,
+  @SerialName("state_checkpoint_hash") val stateCheckpointHash: String?,
+  @SerialName("gas_used") val gasUsed: String,
+  val success: Boolean,
+  @SerialName("vm_status") val vmStatus: String,
+  @SerialName("accumulator_root_hash") val accumulatorRootHash: String,
+  // val changes: List<WriteSetChange>,
+  val timestamp: String,
+) : TransactionResponse()
+
 @Serializable sealed class TransactionPayloadResponse
 
 @Serializable


### PR DESCRIPTION
## Description:

At [DeSpread](https://despread.io), we are implementing an our Aptos [explorer](https://vp.despreadlabs.io/explorer/mainnet/aptos) using the Kaptos Kotlin SDK for Aptos. During the process, we encountered a need to serialize a new transaction response type, `"state_checkpoint_transaction"`. This PR adds support for serializing the `"state_checkpoint_transaction"` transaction response type in the Kaptos SDK.

### Key Changes:
1. **Addition of `"state_checkpoint_transaction"` Transaction Response**:
   - We have added support for the `"state_checkpoint_transaction"` transaction response type in the Kaptos SDK by updating the relevant data classes to allow for serialization of this new type.

2. **Code Modifications**:
   - Updated the `TransactionResponse` data class to include a field for handling the `"state_checkpoint_transaction"` transaction type.
   - Added test cases to ensure proper serialization and deserialization of the new transaction type.

### Testing:
   - These changes have already been implemented in our repository on the [feature/add-statecheckpoint-tx-response](https://github.com/DeSpread/kaptos/tree/feature/add-statecheckpoint-tx-response) branch. We have built the modified Kaptos SDK into a JAR file, imported it into our project, and have thoroughly tested it.
   - The modified SDK correctly handles the `"state_checkpoint_transaction"` transaction type within our explorer implementation.

## Linked Issues:
- #8 

## Additional Notes:
- This PR extends the Kaptos SDK to support the `"state_checkpoint_transaction"` transaction type, a requirement for DeSpread's current project.
- Please feel free to provide any feedback or request further changes.