### PR TITLE
fix: Correctly serialize MoveVector

### DIFF
--- a/lib/src/commonMain/kotlin/xyz/mcxross/kaptos/serialize/MoveVectorSerializer.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/kaptos/serialize/MoveVectorSerializer.kt
@@ -32,7 +32,6 @@ class MoveVectorSerializer<T : EntryFunctionArgument>(
   override val descriptor: SerialDescriptor = listSerialDescriptor(elementSerializer.descriptor)
 
   override fun serialize(encoder: Encoder, value: MoveVector<T>) {
-    encoder.encodeCollection(descriptor, value.serialize().size) {}
     encoder.encodeCollection(descriptor, value.values.size) {
       for (element in value.values) {
         elementSerializer.serialize(encoder, element)

--- a/lib/src/commonTest/kotlin/xyz/mcxross/kaptos/unit/serialize/MoveVectorSerializerTest.kt
+++ b/lib/src/commonTest/kotlin/xyz/mcxross/kaptos/unit/serialize/MoveVectorSerializerTest.kt
@@ -1,0 +1,42 @@
+package xyz.mcxross.kaptos.unit.serialize
+
+import xyz.mcxross.bcs.Bcs
+import kotlin.test.Test
+import xyz.mcxross.kaptos.model.MoveVector
+import kotlin.test.assertContentEquals
+
+class MoveVectorSerializerTest {
+    @Test()
+    fun `can serialize a vector with less than 128 items`() {
+        val base = listOf(1.toByte(), 2.toByte(), 3.toByte()).toByteArray()
+        val vec = MoveVector.u8(base)
+
+        val encoded = Bcs.encodeToByteArray(vec)
+        val expected = listOf(3.toByte(), 1.toByte(), 2.toByte(), 3.toByte()).toByteArray()
+
+        assertContentEquals(expected, encoded)
+    }
+
+    @Test()
+    fun `can serialize an empty vector`() {
+        val base = emptyList<Byte>().toByteArray()
+        val vec = MoveVector.u8(base)
+
+        val encoded = Bcs.encodeToByteArray(vec)
+        val expected = listOf(0.toByte()).toByteArray()
+
+        assertContentEquals(expected, encoded)
+    }
+
+    @Test()
+    fun `can serialize a vector with 128 items`() {
+        val base = ByteArray(128) { it.toByte() }
+        val vec = MoveVector.u8(base)
+
+        val encoded = Bcs.encodeToByteArray(vec)
+        val expectedLengthTag = listOf(0x80.toByte(), 0x01.toByte()).toByteArray()
+        val expected = expectedLengthTag + base
+
+        assertContentEquals(expected, encoded)
+    }
+}


### PR DESCRIPTION
MoveVector serialization was previously broken, causing NPE for any vector greater than length 0.

Lets fix the serialization and add some test coverage

Closes #21 