### PR TITLE
Add support for vector deserialization

### DIFF
--- a/lib/src/commonMain/kotlin/xyz/mcxross/kaptos/serialize/MoveVectorSerializer.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/kaptos/serialize/MoveVectorSerializer.kt
@@ -21,6 +21,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.listSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.encoding.decodeStructure
 import kotlinx.serialization.encoding.encodeCollection
 import xyz.mcxross.kaptos.model.EntryFunctionArgument
 import xyz.mcxross.kaptos.model.MoveVector
@@ -40,6 +41,13 @@ class MoveVectorSerializer<T : EntryFunctionArgument>(
   }
 
   override fun deserialize(decoder: Decoder): MoveVector<T> {
-    return MoveVector(listOf())
+    return MoveVector(
+        decoder.decodeStructure(descriptor) {
+            val size = decodeCollectionSize(descriptor)
+            List(size) { i ->
+                decodeSerializableElement(descriptor, i, elementSerializer)
+            }
+        }
+    )
   }
 }

--- a/lib/src/commonTest/kotlin/xyz/mcxross/kaptos/unit/serialize/MoveVectorSerializerTest.kt
+++ b/lib/src/commonTest/kotlin/xyz/mcxross/kaptos/unit/serialize/MoveVectorSerializerTest.kt
@@ -3,7 +3,10 @@ package xyz.mcxross.kaptos.unit.serialize
 import xyz.mcxross.bcs.Bcs
 import kotlin.test.Test
 import xyz.mcxross.kaptos.model.MoveVector
+import xyz.mcxross.kaptos.model.U8
+import kotlin.test.Ignore
 import kotlin.test.assertContentEquals
+import kotlin.test.assertFailsWith
 
 class MoveVectorSerializerTest {
     @Test()
@@ -38,5 +41,47 @@ class MoveVectorSerializerTest {
         val expected = expectedLengthTag + base
 
         assertContentEquals(expected, encoded)
+    }
+
+    @Test
+    fun `can deserialize a vector with less than 128 items`() {
+        val encoded = listOf(3.toByte(), 1.toByte(), 2.toByte(), 3.toByte()).toByteArray()
+
+        val decoded: MoveVector<U8> = Bcs.decodeFromByteArray(encoded)
+        val expected = MoveVector.u8(listOf(1.toByte(), 2.toByte(), 3.toByte()).toByteArray())
+
+        assertContentEquals(expected.values, decoded.values)
+    }
+
+    @Test
+    fun `can deserialize an empty vector`() {
+        val encoded = listOf(0.toByte()).toByteArray()
+
+        val decoded: MoveVector<U8> = Bcs.decodeFromByteArray(encoded)
+        val expected = MoveVector.u8(emptyList<Byte>().toByteArray())
+
+        assertContentEquals(expected.values, decoded.values)
+    }
+
+    @Test // Fails due to incorrect size check in bcs lib, will circle back after fixing bcs
+    @Ignore
+    fun `can deserialize a vector with 128 items`() {
+        val base = ByteArray(128) { it.toByte() }
+        val expectedLengthTag = listOf(0x80.toByte(), 0x01.toByte()).toByteArray()
+        val encoded = expectedLengthTag + base
+
+        val decoded: MoveVector<U8> = Bcs.decodeFromByteArray(encoded)
+        val expected = MoveVector.u8(base)
+
+        assertContentEquals(expected.values, decoded.values)
+    }
+
+    @Test
+    fun `should throw error when deserializing empty byte array`() {
+        val emptyInput = byteArrayOf()
+
+        assertFailsWith<Exception> {
+            Bcs.decodeFromByteArray<MoveVector<U8>>(emptyInput)
+        }
     }
 }


### PR DESCRIPTION
The tests here revealed an issue with the underlying bcs library, such that this only works for vectors under length 128.

The bcs library does not properly decode vector length as a uleb, it instead treats it as a signed byte.

I will be following up with a PR to the bcs library, once the bcs library is patched.

Closes #22 